### PR TITLE
Fix zoeken popup UI interactions

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -158,6 +158,31 @@
 
     .vragenai-question-form textarea.vragenai-question-form__input {
         background-color: transparent !important;
+        box-shadow: none !important;
+        filter: none !important;
+    }
+
+    .vragenai-popup-container.vragenai-container {
+        position: fixed !important;
+        inset: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        height: 100dvh !important;
+        align-items: center !important;
+        justify-content: center !important;
+    }
+
+    .vragenai-popup-container.vragenai-container .vragenai-popup {
+        margin: auto !important;
+        max-height: calc(100vh - 2rem) !important;
+        max-height: calc(100dvh - 2rem) !important;
+    }
+
+    .button-face-delayed-fill {
+        transition-property: transform, color, background-color, border-color !important;
+        transition-duration: 150ms, 150ms, 150ms, 150ms !important;
+        transition-timing-function: ease-in-out !important;
+        transition-delay: 0ms, 150ms, 150ms, 150ms !important;
     }
 
     .mt {

--- a/resources/views/partials/buttons/_primary-border-alt.antlers.html
+++ b/resources/views/partials/buttons/_primary-border-alt.antlers.html
@@ -1,3 +1,3 @@
-{{ partial:buttons/base :link="link" button_class="border {{ class}}" background_class="{{ background_class }}" }}
+{{ partial:buttons/base :link="link" button_class="button-face-delayed-fill border {{ class}}" background_class="{{ background_class }}" }}
     {{ slot }}
 {{ /partial:buttons/base }}


### PR DESCRIPTION
## Summary
- center the Vragen.ai popup overlay in the full viewport and remove the textarea shadow
- delay border-alt button fill/text transitions until after the offset transform
- avoid the PHP 8.5 PDO SSL CA deprecation warning

## Verification
- php -l config/database.php
- npm run build
- browser checked Vragen.ai overlay geometry and button transition timing