### PR TITLE
Match delayed button movement timing

### DIFF
--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -179,10 +179,35 @@
     }
 
     .button-face-delayed-fill {
-        transition-property: transform, color, background-color, border-color !important;
-        transition-duration: 150ms, 150ms, 150ms, 150ms !important;
-        transition-timing-function: ease-in-out !important;
-        transition-delay: 0ms, 150ms, 150ms, 150ms !important;
+        transition-property: transform, translate, scale, rotate, color, background-color, border-color !important;
+        transition-duration:
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration) !important;
+        transition-timing-function:
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function),
+            var(--default-transition-timing-function) !important;
+        transition-delay:
+            0ms,
+            0ms,
+            0ms,
+            0ms,
+            var(--default-transition-duration),
+            var(--default-transition-duration),
+            var(--default-transition-duration) !important;
+    }
+
+    :is(a, button).group:hover > .button-face-delayed-fill {
+        transition-delay: 0ms, 0ms, 0ms, 0ms, 0ms, 0ms, 0ms !important;
     }
 
     .mt {


### PR DESCRIPTION
## Summary\n- include Tailwind's transform longhands in the delayed button face transition\n- use Tailwind's default transition duration and easing so movement matches the original button behavior\n- keep the fill/text/border fade delayed until the movement completes\n\n## Verification\n- npm run build\n- cleared/warmed Statamic stache in the zoeken Orbit container\n- loaded https://zoeken.dutchlaravelfoundation.test/ and hover-smoked the target button with agent-browser\n