### PR TITLE
Use featured images for article OG metadata

### DIFF
--- a/resources/views/layouts/layout.antlers.html
+++ b/resources/views/layouts/layout.antlers.html
@@ -55,7 +55,12 @@
     <meta property="og:description" content="{{ meta_description_text }}">
     {{ /if }}
     {{ opengraph_image = opengraph:opengraph_image ?? "/og-image.png" }}
-    <meta property="og:image" content="{{ site:url }}{{ opengraph_image }}">
+    {{ if collection == "knowledge" || collection == "insights" }}
+        {{ if featured_image }}
+            {{ opengraph_image = featured_image:url }}
+        {{ /if }}
+    {{ /if }}
+    <meta property="og:image" content="{{ config:app:url }}{{ opengraph_image }}">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="theme-color" content="#ffffff">
     <link rel="stylesheet" href="https://use.typekit.net/oap5ojy.css">

--- a/tests/Feature/OpenGraphImageTest.php
+++ b/tests/Feature/OpenGraphImageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Statamic\Entries\Entry;
+use Statamic\Facades\Entry as EntryRepository;
+use Tests\TestCase;
+
+class OpenGraphImageTest extends TestCase
+{
+    public function testPagesWithoutAFeaturedImageUseTheDefaultOpenGraphImage(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $this->assertStringContainsString(
+            '<meta property="og:image" content="' . config('app.url') . '/og-image.png">',
+            $response->getContent(),
+        );
+    }
+
+    public function testKnowledgeArticlesUseTheirFeaturedImageAsTheOpenGraphImage(): void
+    {
+        $entry = $this->firstArticleWithFeaturedImage('knowledge');
+
+        if ($entry === null) {
+            $this->markTestSkipped('No published knowledge article with a featured image present');
+        }
+
+        $response = $this->get($entry->url());
+
+        $response->assertOk();
+        $this->assertStringContainsString(
+            '<meta property="og:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
+            $response->getContent(),
+        );
+    }
+
+    public function testNewsArticlesUseTheirFeaturedImageAsTheOpenGraphImage(): void
+    {
+        $entry = $this->firstArticleWithFeaturedImage('insights');
+
+        if ($entry === null) {
+            $this->markTestSkipped('No published news article with a featured image present');
+        }
+
+        $response = $this->get($entry->url());
+
+        $response->assertOk();
+        $this->assertStringContainsString(
+            '<meta property="og:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
+            $response->getContent(),
+        );
+    }
+
+    private function firstArticleWithFeaturedImage(string $collection): ?Entry
+    {
+        return EntryRepository::query()
+            ->where('collection', $collection)
+            ->where('published', true)
+            ->get()
+            ->first(fn (Entry $entry): bool => filled($entry->get('featured_image')));
+    }
+}


### PR DESCRIPTION
## Summary
- Use featured images as the Open Graph image for knowledge and news articles
- Keep the existing default OG image fallback for pages without article featured images
- Add feature coverage for fallback, knowledge articles, and news articles

## Tests
- php vendor/bin/phpunit tests/Feature/OpenGraphImageTest.php
- php vendor/bin/phpunit
- git diff --check