### PR TITLE
Add X card metadata for social images

### DIFF
--- a/resources/views/layouts/layout.antlers.html
+++ b/resources/views/layouts/layout.antlers.html
@@ -61,6 +61,12 @@
         {{ /if }}
     {{ /if }}
     <meta property="og:image" content="{{ config:app:url }}{{ opengraph_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ if site_title }}{{ site_title }} - {{ /if }}{{ site_name }}">
+    {{ if meta_description_text }}
+    <meta name="twitter:description" content="{{ meta_description_text }}">
+    {{ /if }}
+    <meta name="twitter:image" content="{{ config:app:url }}{{ opengraph_image }}">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="theme-color" content="#ffffff">
     <link rel="stylesheet" href="https://use.typekit.net/oap5ojy.css">

--- a/tests/Feature/OpenGraphImageTest.php
+++ b/tests/Feature/OpenGraphImageTest.php
@@ -19,6 +19,14 @@ class OpenGraphImageTest extends TestCase
             '<meta property="og:image" content="' . config('app.url') . '/og-image.png">',
             $response->getContent(),
         );
+        $this->assertStringContainsString(
+            '<meta name="twitter:card" content="summary_large_image">',
+            $response->getContent(),
+        );
+        $this->assertStringContainsString(
+            '<meta name="twitter:image" content="' . config('app.url') . '/og-image.png">',
+            $response->getContent(),
+        );
     }
 
     public function testKnowledgeArticlesUseTheirFeaturedImageAsTheOpenGraphImage(): void
@@ -36,6 +44,10 @@ class OpenGraphImageTest extends TestCase
             '<meta property="og:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
             $response->getContent(),
         );
+        $this->assertStringContainsString(
+            '<meta name="twitter:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
+            $response->getContent(),
+        );
     }
 
     public function testNewsArticlesUseTheirFeaturedImageAsTheOpenGraphImage(): void
@@ -51,6 +63,10 @@ class OpenGraphImageTest extends TestCase
         $response->assertOk();
         $this->assertStringContainsString(
             '<meta property="og:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
+            $response->getContent(),
+        );
+        $this->assertStringContainsString(
+            '<meta name="twitter:image" content="' . config('app.url') . $entry->augmentedValue('featured_image')->value()->url() . '">',
             $response->getContent(),
         );
     }


### PR DESCRIPTION
## Summary
- Add Twitter/X card metadata alongside existing Open Graph tags.
- Use summary_large_image so X can render the article image prominently.
- Reuse the same computed title, description, and image URL as the Open Graph metadata.
- Extend metadata tests for default, knowledge, and news article images.

## Root Cause
The deployed page already emits an absolute og:image, and the image is publicly fetchable by Twitterbot, but the page emits no twitter:* card metadata. X/Twitter cards still depend on twitter:card to select a card layout, with twitter:image providing the image URL.

## Tests
- php vendor/bin/phpunit tests/Feature/OpenGraphImageTest.php
- php vendor/bin/phpunit
- git diff --check

## Notes
- php artisan tinker render probing is noisy locally because existing Statamic cache files are owned by root, but HTTP feature tests render successfully.