### PR TITLE
Use podcast thumbnails for social cards

### DIFF
--- a/resources/views/layouts/layout.antlers.html
+++ b/resources/views/layouts/layout.antlers.html
@@ -59,14 +59,23 @@
         {{ if featured_image }}
             {{ opengraph_image = featured_image:url }}
         {{ /if }}
+    {{ elseif collection == "podcasts" }}
+        {{ if thumbnail_url }}
+            {{ opengraph_image = thumbnail_url }}
+        {{ /if }}
     {{ /if }}
-    <meta property="og:image" content="{{ config:app:url }}{{ opengraph_image }}">
+    {{ if opengraph_image | contains('://') }}
+        {{ social_image_url = opengraph_image }}
+    {{ else }}
+        {{ social_image_url = config:app:url + opengraph_image }}
+    {{ /if }}
+    <meta property="og:image" content="{{ social_image_url }}">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ if site_title }}{{ site_title }} - {{ /if }}{{ site_name }}">
     {{ if meta_description_text }}
     <meta name="twitter:description" content="{{ meta_description_text }}">
     {{ /if }}
-    <meta name="twitter:image" content="{{ config:app:url }}{{ opengraph_image }}">
+    <meta name="twitter:image" content="{{ social_image_url }}">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="theme-color" content="#ffffff">
     <link rel="stylesheet" href="https://use.typekit.net/oap5ojy.css">

--- a/tests/Feature/OpenGraphImageTest.php
+++ b/tests/Feature/OpenGraphImageTest.php
@@ -29,6 +29,14 @@ class OpenGraphImageTest extends TestCase
         );
     }
 
+    public function testDefaultOpenGraphImageIsLargeEnoughForSocialCards(): void
+    {
+        [$width, $height] = getimagesize(public_path('og-image.png'));
+
+        $this->assertGreaterThanOrEqual(1200, $width);
+        $this->assertGreaterThanOrEqual(600, $height);
+    }
+
     public function testKnowledgeArticlesUseTheirFeaturedImageAsTheOpenGraphImage(): void
     {
         $entry = $this->firstArticleWithFeaturedImage('knowledge');
@@ -71,6 +79,28 @@ class OpenGraphImageTest extends TestCase
         );
     }
 
+    public function testPodcastEntriesUseTheirThumbnailAsTheSocialImage(): void
+    {
+        $entry = $this->firstPodcastWithThumbnail();
+
+        if ($entry === null) {
+            $this->markTestSkipped('No published podcast entry with a thumbnail URL present');
+        }
+
+        $response = $this->get($entry->url());
+        $thumbnailUrl = $entry->get('thumbnail_url');
+
+        $response->assertOk();
+        $this->assertStringContainsString(
+            '<meta property="og:image" content="' . $thumbnailUrl . '">',
+            $response->getContent(),
+        );
+        $this->assertStringContainsString(
+            '<meta name="twitter:image" content="' . $thumbnailUrl . '">',
+            $response->getContent(),
+        );
+    }
+
     private function firstArticleWithFeaturedImage(string $collection): ?Entry
     {
         return EntryRepository::query()
@@ -78,5 +108,14 @@ class OpenGraphImageTest extends TestCase
             ->where('published', true)
             ->get()
             ->first(fn (Entry $entry): bool => filled($entry->get('featured_image')));
+    }
+
+    private function firstPodcastWithThumbnail(): ?Entry
+    {
+        return EntryRepository::query()
+            ->where('collection', 'podcasts')
+            ->where('published', true)
+            ->get()
+            ->first(fn (Entry $entry): bool => filled($entry->get('thumbnail_url')));
     }
 }


### PR DESCRIPTION
## Summary
- use podcast `thumbnail_url` as the Open Graph and X/Twitter card image
- normalize local and remote social image URLs before rendering metadata
- add regression coverage for podcast cards and default social image dimensions

## Verification
- ./vendor/bin/phpunit tests/Feature/OpenGraphImageTest.php --colors=never
- ./vendor/bin/phpunit --colors=never
- npm run build

## Notes
The default `/og-image.png` is 1200x630. Main already emits `twitter:card=summary_large_image`; this PR makes podcast images use the remote YouTube thumbnail URL directly instead of falling back to the default image.