### PR TITLE
Keep Envoy release metadata outside the worktree

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -282,8 +282,8 @@
     php please static:clear
     php please static:warm
 
-    printf '%s\n' "$REVISION" > "$RELEASE_PATH/.revision"
-    printf '%s\n' "$PREVIOUS_RELEASE" > "$RELEASE_PATH/.previous-release"
+    printf '%s\n' "$REVISION" > "$RELEASE_PATH/.git/deployed-revision"
+    printf '%s\n' "$PREVIOUS_RELEASE" > "$RELEASE_PATH/.git/previous-release"
 
     activate_release "$RELEASE_PATH"
     ACTIVATED=1

--- a/tests/Feature/EnvoyDeploymentTest.php
+++ b/tests/Feature/EnvoyDeploymentTest.php
@@ -75,6 +75,28 @@ final class EnvoyDeploymentTest extends TestCase
         $this->assertStringNotContainsString('!glide', $statamicGitignore);
     }
 
+    public function testItStoresReleaseRecordsOutsideTheWorkingTree(): void
+    {
+        $recipe = $this->recipe();
+
+        $this->assertStringContainsString(
+            '> "$RELEASE_PATH/.git/deployed-revision"',
+            $recipe,
+        );
+        $this->assertStringContainsString(
+            '> "$RELEASE_PATH/.git/previous-release"',
+            $recipe,
+        );
+        $this->assertStringNotContainsString(
+            '> "$RELEASE_PATH/.revision"',
+            $recipe,
+        );
+        $this->assertStringNotContainsString(
+            '> "$RELEASE_PATH/.previous-release"',
+            $recipe,
+        );
+    }
+
     public function testItCompilesForInspectionWithoutConnectingToProduction(): void
     {
         $projectPath = dirname(__DIR__, 2);


### PR DESCRIPTION
## Summary

- stores Envoy release records inside the release repository's `.git` directory
- prevents `.revision` and `.previous-release` from appearing as untracked production files
- keeps the deployed revision and previous-release rollback record available without breaking the next deployment's dirty-tree guard

## Production finding

The first hardened production deployment completed successfully at `189a22955f24edfe0f3ba38cc955d29d64fa6d07`, but its two release-record files made the new checkout appear dirty. Those records were moved into `.git` on the live release, and production is clean again.

This follow-up changes future releases only. It does not alter site content or require an immediate production redeployment.

## Verification

- regression test failed before the implementation change
- Envoy deployment tests: 7 passed, 46 assertions
- full PHP test suite
- rendered Envoy Bash syntax
- `git diff --check`
